### PR TITLE
add register X-Real-IP header under proxy

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 		TemplatePath  string
 		Addr          string
 		RecalcTimeout _duration
+		UnderProxy    bool
 	}
 
 	WebsocketTimeout struct {

--- a/config/henhouse.toml
+++ b/config/henhouse.toml
@@ -16,6 +16,7 @@ www_path = "/var/www/henhouse"
 template_path = "/var/lib/henhouse/templates"
 addr = ":8000"
 recalc_timeout = "1m"
+under_proxy = true
 
 [WebsocketTimeout]
 info = "1s"

--- a/main.go
+++ b/main.go
@@ -258,7 +258,8 @@ func initGame(database *sql.DB, cfg config.Config) (err error) {
 	err = scoreboard.Scoreboard(database, &g,
 		cfg.Scoreboard.WwwPath,
 		cfg.Scoreboard.TemplatePath,
-		cfg.Scoreboard.Addr)
+		cfg.Scoreboard.Addr,
+		cfg.Scoreboard.UnderProxy)
 
 	return
 }

--- a/scoreboard/auth.go
+++ b/scoreboard/auth.go
@@ -26,6 +26,19 @@ const (
 
 var authEnabled = true
 
+var underProxy bool
+
+func getClientAddr(r *http.Request) (clientAddr string) {
+    
+    if underProxy {
+        clientAddr = r.Header.Get("x-real-ip")
+    } else {
+        clientAddr = r.RemoteAddr
+    }
+              
+    return
+}
+
 func genSession() (s string, err error) {
 
 	sessionLen := 256
@@ -115,7 +128,7 @@ func authHandler(database *sql.DB, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("auth ip: %s, access_token: %s", r.RemoteAddr, token)
+	log.Printf("auth ip: %s, access_token: %s", getClientAddr(r), token)
 
 	teamID, err := db.GetTeamIDByToken(database, token)
 	if err != nil {
@@ -135,7 +148,7 @@ func authHandler(database *sql.DB, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("Success auth ip: %s team ID: %d", r.RemoteAddr, teamID)
+	log.Printf("Success auth ip: %s team ID: %d", getClientAddr(r), teamID)
 
 	// Success auth
 	http.Redirect(w, r, "/", 303)

--- a/scoreboard/scoreboard.go
+++ b/scoreboard/scoreboard.go
@@ -411,11 +411,12 @@ func sponsorsHandler(w http.ResponseWriter, r *http.Request) {
 
 // Scoreboard implements web scoreboard
 func Scoreboard(database *sql.DB, game *game.Game,
-	wwwPath, tmpltsPath, addr string) (err error) {
+	wwwPath, tmpltsPath, addr string, proxy bool) (err error) {
 
 	contestStatus = contestStateNotAvailable
 	gameShim = game
 	templatePath = tmpltsPath
+	underProxy = proxy
 
 	scoreCache, err = gameShim.Scoreboard()
 	if err != nil {

--- a/scoreboard/scoreboard_test.go
+++ b/scoreboard/scoreboard_test.go
@@ -436,11 +436,13 @@ func TestScoreboard(*testing.T) {
 	}
 
 	ScoreboardRecalcTimeout = time.Second / 10
+	
+	proxy := false
 
 	go func() {
 		_, filename, _, _ := runtime.Caller(0)
 		err = Scoreboard(database, &game, filepath.Dir(filename)+"/www",
-			filepath.Dir(filename)+"/templates", addr)
+			filepath.Dir(filename)+"/templates", addr, proxy)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Henhouse don't write true client address when work under proxy. For example, under nginx. 

- The **under_proxy** parameter was added to the config section **[Scoreboard]** 
- The **getClientAddr** function added for printing to log  the **X-Real-IP** header or the **ReboteAddr** according  parameter  **under_proxy**